### PR TITLE
[Points] Address sender, not target, on error.

### DIFF
--- a/src/me/krickl/memebotj/InternalCommands/PointsCommand.scala
+++ b/src/me/krickl/memebotj/InternalCommands/PointsCommand.scala
@@ -52,7 +52,7 @@ class PointsCommand(channel: String, command: String, dbprefix: String) extends 
 								channelHandler.sendMessage(f"${sender.getUsername}: You sent $number ${channelHandler.getBuiltInStrings.get("CURRENCY_EMOTE")} to ${target.getUsername}", this.getChannelOrigin)
 							}
 						} else {
-							channelHandler.sendMessage(f"${target.getUsername}: Sorry you don't have ${number + tax} ${channelHandler.getBuiltInStrings.get("CURRENCY_EMOTE")}", this.getChannelOrigin)
+							channelHandler.sendMessage(f"${sender.getUsername}: Sorry you don't have ${number + tax} ${channelHandler.getBuiltInStrings.get("CURRENCY_EMOTE")}", this.getChannelOrigin)
 						}
 					}
 				} catch {

--- a/src/me/krickl/memebotj/InternalCommands/PointsCommand.scala
+++ b/src/me/krickl/memebotj/InternalCommands/PointsCommand.scala
@@ -50,9 +50,9 @@ class PointsCommand(channel: String, command: String, dbprefix: String) extends 
 								sender.setPoints(sender.points - (number + tax))
 								target.setPoints(target.points + number)
 								channelHandler.sendMessage(f"${sender.getUsername}: You sent $number ${channelHandler.getBuiltInStrings.get("CURRENCY_EMOTE")} to ${target.getUsername}", this.getChannelOrigin)
+							} else {
+								channelHandler.sendMessage(f"${sender.getUsername}: Sorry you don't have ${number + tax} ${channelHandler.getBuiltInStrings.get("CURRENCY_EMOTE")}", this.getChannelOrigin)
 							}
-						} else {
-							channelHandler.sendMessage(f"${sender.getUsername}: Sorry you don't have ${number + tax} ${channelHandler.getBuiltInStrings.get("CURRENCY_EMOTE")}", this.getChannelOrigin)
 						}
 					}
 				} catch {


### PR DESCRIPTION
`sender` is the one missing points, so `sender` should be addressed in the error message.