### PR TITLE
Updating PersonalBestCommand, WorldRecordCommand

### DIFF
--- a/src/main/java/me/krickl/memebotj/Commands/Internal/WorldRecordCommand.java
+++ b/src/main/java/me/krickl/memebotj/Commands/Internal/WorldRecordCommand.java
@@ -23,8 +23,13 @@ public class WorldRecordCommand extends CommandHandler {
 
     @Override
     public void commandScript(UserHandler sender, String[] data) {
-        getChannelHandler().getSpeedRunComAPI().updateGame();
-        getChannelHandler().sendMessage(formatString(sender), getChannelHandler().getChannel(), sender, isWhisper());
+        if (getChannelHandler().getSpeedRunComAPI().getGame() != null) {
+            getChannelHandler().getSpeedRunComAPI().updateGame();
+            getChannelHandler().sendMessage(formatString(sender), getChannelHandler().getChannel(), sender, isWhisper());
+        } else {
+            getChannelHandler().sendMessage(Memebot.formatText("WR_NO_GAME_AVAILABLE", getChannelHandler(), sender, this, true,
+                    new String[]{}, ""), getChannelHandler().getChannel(), sender, isWhisper());
+        }
     }
 
     private String formatString(UserHandler sender) {

--- a/src/main/java/me/krickl/memebotj/SpeedrunCom/SpeedRunComAPI.java
+++ b/src/main/java/me/krickl/memebotj/SpeedrunCom/SpeedRunComAPI.java
@@ -17,6 +17,7 @@ import retrofit2.Retrofit;
 import retrofit2.converter.gson.GsonConverterFactory;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.logging.Level;
 
 /**
@@ -67,7 +68,10 @@ public class SpeedRunComAPI {
     public void updateUser() {
         Call<UsersLookup> userLookup = service.lookupUser(channelHandler.getBroadcaster());
         try {
-            user = userLookup.execute().body().getData().get(0);
+            ArrayList<UserObject> users = userLookup.execute().body().getData();
+            if (!users.isEmpty()) {
+                user = users.get(0);
+            }
         } catch (IOException | ArrayIndexOutOfBoundsException e) {
             e.printStackTrace();
         }
@@ -75,22 +79,26 @@ public class SpeedRunComAPI {
 
     public void updateGame() {
         String currentGame = channelHandler.getCurrentGame();
-        if (game == null) {
-            Call<Games> gameLookup = service.lookupGame(currentGame, "categories");
-            try {
-                game = gameLookup.execute().body().getData().get(0);
-            } catch (IOException e) {
-                e.printStackTrace();
+        if (!currentGame.equals("Not Playing") && !currentGame.equals("")) {
+            if (game == null) {
+                Call<Games> gameLookup = service.lookupGame(currentGame, "categories");
+                try {
+                    game = gameLookup.execute().body().getData().get(0);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+                return;
             }
-            return;
-        }
-        if (!game.getName().equals(currentGame)) {
-            Call<Games> gameLookup = service.lookupGame(currentGame, "categories");
-            try {
-                game = gameLookup.execute().body().getData().get(0);
-            } catch (IOException e) {
-                e.printStackTrace();
+            if (!game.getName().equals(currentGame)) {
+                Call<Games> gameLookup = service.lookupGame(currentGame, "categories");
+                try {
+                    game = gameLookup.execute().body().getData().get(0);
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
             }
+        } else {
+            game = null;
         }
     }
 

--- a/src/main/resources/local/engb.properties
+++ b/src/main/resources/local/engb.properties
@@ -175,9 +175,13 @@ UNEQUIP_OK={sender}: You put your item back into your bag!
 UNEQUIP_FAIL={sender}: Failed to unequip items!
 
 PB_CATEGORY={broadcaster}'s PB in {game} {param1} is {param2}
+PB_ALL_GAME={broadcaster}'s PBs in {game} are: {param1}
 PB_NO_CATEGORY_SET=Can't detect category from title
+PB_NO_USER=Couldn't find speedrun.com user, either the broadcaster has no account or it's not linked to Twitch
+PB_NO_USER_AND_GAME=Couldn't find speedrun.com user, additionally no game was set or returned by Twitch API
 
 WR_CATEGORY=The current World Record in {game} {param1} is {param2} held by {param3}
+WR_NO_GAME_AVAILABLE=Couldn't find game or game is not set on Twitch
 
 #Memebot.formatText("", channelHandler, sender, this, true, Array())
 


### PR DESCRIPTION
PersonalBestCommand now contains a list command, it will also be used as a fallback if no category is set.
Correctly handle the case if no speedrun.com user is detected
PersonalBestCommand will tell if user couldn't be found
Correctly handle the case if no game is set
Bot PB and WR Command will act better if anything is missing